### PR TITLE
Add git to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:alpine AS builder
+RUN apk add git
 
 ADD ./ /go/src/github.com/ravens/modem_exporter/
 


### PR DESCRIPTION
Build fails on Ubuntu 20.04 aarch64 using `docker build .`

```
user@server:~/modem_exporter$ docker build -t modemmanager-exporter:v1 .
Sending build context to Docker daemon  197.1kB
Step 1/6 : FROM golang:alpine AS builder
alpine: Pulling from library/golang
df9b9388f04a: Pull complete
52dc419b0ee2: Pull complete
25bc292e5bac: Pull complete
6858aa20941b: Pull complete
9a8029b02d49: Pull complete
Digest: sha256:42d35674864fbb577594b60b84ddfba1be52b4d4298c961b46ba95e9fb4712e8
Status: Downloaded newer image for golang:alpine
 ---> dd6fd110e957
Step 2/6 : ADD ./ /go/src/github.com/ravens/modem_exporter/
 ---> 9e2684597965
Step 3/6 : RUN set -ex &&   cd /go/src/github.com/ravens/modem_exporter &&   CGO_ENABLED=0 go build         -v -a         -ldflags '-extldflags "-static"' &&   mv ./modem_exporter /usr/bin/modem_exporter
 ---> Running in 126caaac4110
+ cd /go/src/github.com/ravens/modem_exporter
+ CGO_ENABLED=0 go build -v -a -ldflags '-extldflags "-static"'
go: downloading github.com/maltegrosse/go-modemmanager v0.1.0
go: downloading github.com/prometheus/client_golang v1.10.0
go: downloading github.com/prometheus/common v0.18.0
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/godbus/dbus/v5 v5.0.3
go: downloading github.com/golang/protobuf v1.4.3
go: downloading github.com/cespare/xxhash/v2 v2.1.1
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/prometheus/procfs v0.6.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: downloading google.golang.org/protobuf v1.23.0
go: downloading golang.org/x/sys v0.0.0-20210309074719-68d13333faf2
go: missing Git command. See https://golang.org/s/gogetcmd
error obtaining VCS status: exec: "git": executable file not found in $PATH
        Use -buildvcs=false to disable VCS stamping.
The command '/bin/sh -c set -ex &&   cd /go/src/github.com/ravens/modem_exporter &&   CGO_ENABLED=0 go build         -v -a         -ldflags '-extldflags "-static"' &&   mv ./modem_exporter /usr/bin/modem_exporter' returned a non-zero code: 1
```